### PR TITLE
feat (profile): added saga store actions and reducers

### DIFF
--- a/ts/features/common/store/reducers/index.ts
+++ b/ts/features/common/store/reducers/index.ts
@@ -8,17 +8,21 @@ import {
   EuCovidCertState
 } from "../../../euCovidCert/store/reducers";
 import { mvlPersistor, PersistedMvlState } from "../../../mvl";
+import { ProfileState } from "../../../../store/reducers/profile";
+import profileReducer from "../../../profile/store/reducers/profile";
 
 export type FeaturesState = {
   euCovidCert: EuCovidCertState;
   mvl: PersistedMvlState;
+  profile: ProfileState;
 };
 
 export type PersistedFeaturesState = FeaturesState & PersistPartial;
 
 const rootReducer = combineReducers<FeaturesState, Action>({
   euCovidCert: euCovidCertReducer,
-  mvl: mvlPersistor
+  mvl: mvlPersistor,
+  profile: profileReducer
 });
 
 const CURRENT_REDUX_FEATURES_STORE_VERSION = 1;

--- a/ts/features/profile/saga/index.ts
+++ b/ts/features/profile/saga/index.ts
@@ -1,0 +1,21 @@
+import { SagaIterator } from "redux-saga";
+import { call, takeLatest } from "typed-redux-saga/macro";
+import { ActionType } from "typesafe-actions";
+import { BackendClient } from "../../../api/backend";
+import { getProfile as loadProfile } from "../store/actions";
+import { handleGetProfile } from "./networking/handleGetProfile";
+/**
+ * Handle the profile requests
+ * @param client
+ */
+export function* watchProfileSaga(
+  client: ReturnType<typeof BackendClient>
+): SagaIterator {
+  // handle the request of getting profile
+  yield* takeLatest(
+    loadProfile.request,
+    function* (action: ActionType<typeof loadProfile.request>) {
+      yield* call(handleGetProfile, client.getProfile, action);
+    }
+  );
+}

--- a/ts/features/profile/saga/networking/__tests__/handleGetProfile.test.ts
+++ b/ts/features/profile/saga/networking/__tests__/handleGetProfile.test.ts
@@ -1,0 +1,29 @@
+import { right } from "fp-ts/lib/Either";
+import { expectSaga } from "redux-saga-test-plan";
+import { getGenericError } from "../../../../../utils/errors";
+import mockedProfile from "../../../../../__mocks__/initializedProfile";
+import { getProfile } from "../../../store/actions";
+import { handleGetProfile } from "../handleGetProfile";
+
+describe("handleGetProfile selector", () => {
+  describe("when user profile is loaded successfully with 200 response status", () => {
+    it("should return the user profile", async () => {
+      const request = jest.fn();
+      request.mockImplementation(() =>
+        right({ status: 200, value: mockedProfile })
+      );
+      await expectSaga(handleGetProfile, request, getProfile.request())
+        .put(getProfile.success(mockedProfile))
+        .run();
+    });
+  });
+  describe("when user profile request fail with a 500 response status", () => {
+    it("should return an error", async () => {
+      const request = jest.fn();
+      request.mockImplementation(() => right({ status: 500 }));
+      await expectSaga(handleGetProfile, request, getProfile.request())
+        .put(getProfile.failure({ ...getGenericError(new Error("Error")) }))
+        .run();
+    });
+  });
+});

--- a/ts/features/profile/saga/networking/handleGetProfile.ts
+++ b/ts/features/profile/saga/networking/handleGetProfile.ts
@@ -21,7 +21,6 @@ export function* handleGetProfile(
     );
 
     if (getProfileResult.isRight()) {
-      // right side of the Either
       if (getProfileResult.value.status === 200) {
         yield* put(loadProfile.success(getProfileResult.value.value));
         return;

--- a/ts/features/profile/saga/networking/handleGetProfile.ts
+++ b/ts/features/profile/saga/networking/handleGetProfile.ts
@@ -34,9 +34,9 @@ export function* handleGetProfile(
     if (getProfileResult.isLeft()) {
       // left side of the Either
       yield* put(
-        loadProfile.failure({
-          ...getGenericError(new Error(readableReport(getProfileResult.value)))
-        })
+        loadProfile.failure(
+          getGenericError(new Error(readableReport(getProfileResult.value)))
+        )
       );
     }
   } catch (error) {

--- a/ts/features/profile/saga/networking/handleGetProfile.ts
+++ b/ts/features/profile/saga/networking/handleGetProfile.ts
@@ -24,21 +24,18 @@ export function* handleGetProfile(
       if (getProfileResult.value.status === 200) {
         yield* put(loadProfile.success(getProfileResult.value.value));
         return;
-      } else {
-        yield* put(
-          loadProfile.failure({ ...getGenericError(new Error(`Error`)) })
-        );
       }
+
+      yield* put(loadProfile.failure(getGenericError(new Error(`Error`))));
+      return;
     }
 
-    if (getProfileResult.isLeft()) {
-      // left side of the Either
-      yield* put(
-        loadProfile.failure(
-          getGenericError(new Error(readableReport(getProfileResult.value)))
-        )
-      );
-    }
+    yield* put(
+      loadProfile.failure(
+        getGenericError(new Error(readableReport(getProfileResult.value)))
+      )
+    );
+    return;
   } catch (error) {
     yield* put(loadProfile.failure(getNetworkError(error)));
   }

--- a/ts/features/profile/saga/networking/handleGetProfile.ts
+++ b/ts/features/profile/saga/networking/handleGetProfile.ts
@@ -1,0 +1,46 @@
+import { ActionType } from "typesafe-actions";
+import { call, put } from "typed-redux-saga/macro";
+import { readableReport } from "italia-ts-commons/lib/reporters";
+import { BackendClient } from "../../../../api/backend";
+import { SagaCallReturnType } from "../../../../types/utils";
+import { getProfile as loadProfile } from "../../store/actions";
+import { getGenericError, getNetworkError } from "../../../../utils/errors";
+
+/**
+ * Handle the remote call to retrieve the profile data
+ * @param getProfile
+ */
+export function* handleGetProfile(
+  getProfile: ReturnType<typeof BackendClient>["getProfile"],
+  _: ActionType<typeof loadProfile.request>
+) {
+  try {
+    const getProfileResult: SagaCallReturnType<typeof getProfile> = yield* call(
+      getProfile,
+      {}
+    );
+
+    if (getProfileResult.isRight()) {
+      // right side of the Either
+      if (getProfileResult.value.status === 200) {
+        yield* put(loadProfile.success(getProfileResult.value.value));
+        return;
+      } else {
+        yield* put(
+          loadProfile.failure({ ...getGenericError(new Error(`Error`)) })
+        );
+      }
+    }
+
+    if (getProfileResult.isLeft()) {
+      // left side of the Either
+      yield* put(
+        loadProfile.failure({
+          ...getGenericError(new Error(readableReport(getProfileResult.value)))
+        })
+      );
+    }
+  } catch (error) {
+    yield* put(loadProfile.failure(getNetworkError(error)));
+  }
+}

--- a/ts/features/profile/store/actions/index.ts
+++ b/ts/features/profile/store/actions/index.ts
@@ -6,9 +6,9 @@ import { InitializedProfile } from "../../../../../definitions/backend/Initializ
  * The user requests the EU Covid certificate, starting from the auth_code
  */
 export const getProfile = createAsyncAction(
-  "PROFILE_REQUEST",
-  "PROFILE_SUCCESS",
-  "PROFILE_FAILURE"
+  "PROFILE_GET_REQUEST",
+  "PROFILE_GET_SUCCESS",
+  "PROFILE_GET_FAILURE"
 )<void, InitializedProfile, NetworkError>();
 
 export type ProfileActions = ActionType<typeof getProfile>;

--- a/ts/features/profile/store/actions/index.ts
+++ b/ts/features/profile/store/actions/index.ts
@@ -1,0 +1,14 @@
+import { ActionType, createAsyncAction } from "typesafe-actions";
+import { NetworkError } from "../../../../utils/errors";
+import { InitializedProfile } from "../../../../../definitions/backend/InitializedProfile";
+
+/**
+ * The user requests the EU Covid certificate, starting from the auth_code
+ */
+export const getProfile = createAsyncAction(
+  "PROFILE_REQUEST",
+  "PROFILE_SUCCESS",
+  "PROFILE_FAILURE"
+)<void, InitializedProfile, NetworkError>();
+
+export type ProfileActions = ActionType<typeof getProfile>;

--- a/ts/features/profile/store/reducers/__tests__/profile.test.ts
+++ b/ts/features/profile/store/reducers/__tests__/profile.test.ts
@@ -1,0 +1,10 @@
+import * as pot from "italia-ts-commons/lib/pot";
+import { appReducer } from "../../../../../store/reducers";
+import { applicationChangeState } from "../../../../../store/actions/application";
+
+describe("Test profile reducer behaviour", () => {
+  it("The initial state should be pot.none", () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    expect(globalState.features.profile).toEqual(pot.none);
+  });
+});

--- a/ts/features/profile/store/reducers/index.ts
+++ b/ts/features/profile/store/reducers/index.ts
@@ -1,0 +1,12 @@
+import { combineReducers } from "redux";
+import profileReducer, { ProfileState } from "./profile";
+
+type ProfileUpdatedState = {
+  profile: ProfileState;
+};
+
+const profileUpdatedReducer = combineReducers<ProfileUpdatedState>({
+  profile: profileReducer
+});
+
+export default profileUpdatedReducer;

--- a/ts/features/profile/store/reducers/profile.ts
+++ b/ts/features/profile/store/reducers/profile.ts
@@ -1,0 +1,27 @@
+import { getType } from "typesafe-actions";
+import * as pot from "italia-ts-commons/lib/pot";
+import { InitializedProfile } from "../../../../../definitions/backend/InitializedProfile";
+import { Action } from "../../../../store/actions/types";
+import { getErrorFromNetworkError } from "../../../../utils/errors";
+import { getProfile } from "../actions";
+
+export type ProfileState = pot.Pot<InitializedProfile, Error>;
+
+const INITIAL_STATE: ProfileState = pot.none;
+
+const profileReducer = (
+  state: ProfileState = INITIAL_STATE,
+  action: Action
+): ProfileState => {
+  switch (action.type) {
+    case getType(getProfile.request):
+      return pot.toLoading(state);
+    case getType(getProfile.success):
+      return pot.some(action.payload);
+    case getType(getProfile.failure):
+      return pot.toError(state, getErrorFromNetworkError(action.payload));
+  }
+  return state;
+};
+
+export default profileReducer;

--- a/ts/sagas/startup.ts
+++ b/ts/sagas/startup.ts
@@ -30,7 +30,8 @@ import {
   pagoPaApiUrlPrefixTest,
   svEnabled,
   usePaginatedMessages,
-  zendeskEnabled
+  zendeskEnabled,
+  newProfileScreenEnabled
 } from "../config";
 import { watchBonusSaga } from "../features/bonus/bonusVacanze/store/sagas/bonusSaga";
 import { watchBonusBpdSaga } from "../features/bonus/bpd/saga";
@@ -76,6 +77,7 @@ import { UIMessageId } from "../store/reducers/entities/messages/types";
 import { watchBonusCdcSaga } from "../features/bonus/cdc/saga";
 import { differentProfileLoggedIn } from "../store/actions/crossSessions";
 import { clearAllMvlAttachments } from "../features/mvl/saga/mvlAttachments";
+import { watchProfileSaga } from "../features/profile/saga";
 import {
   startAndReturnIdentificationResult,
   watchIdentification
@@ -411,6 +413,11 @@ export function* initializeApplicationSaga(): Generator<
   if (mvlEnabled) {
     // Start watching for MVL actions
     yield* fork(watchMvlSaga, sessionToken);
+  }
+
+  if (newProfileScreenEnabled) {
+    // Start watching for new profile actions
+    yield* fork(watchProfileSaga, backendClient);
   }
 
   // Load the user metadata

--- a/ts/store/actions/types.ts
+++ b/ts/store/actions/types.ts
@@ -24,6 +24,7 @@ import { SatispayActions } from "../../features/wallet/onboarding/satispay/store
 import { ZendeskSupportActions } from "../../features/zendesk/store/actions";
 import { GlobalState } from "../reducers/types";
 import { CdcActions } from "../../features/bonus/cdc/store/actions";
+import { ProfileActions as NewProfileActions } from "../../features/profile/store/actions";
 import { AnalyticsActions } from "./analytics";
 import { ApplicationActions } from "./application";
 import { AuthenticationActions } from "./authentication";
@@ -98,7 +99,8 @@ export type Action =
   | SvActions
   | MvlActions
   | ZendeskSupportActions
-  | CdcActions;
+  | CdcActions
+  | NewProfileActions;
 
 export type Dispatch = DispatchAPI<Action>;
 


### PR DESCRIPTION
## Short description
In this PR it was added the required store with actions and reducers related to the new profile feature. As feature all the related logic is confined in the ts/features directory.

## List of changes proposed in this pull request
- Added store/actions
- Added saga/networking/handleGetProfile
- Added saga watchers
- Added profile reducers
- Added test

## How to test
