### PR TITLE
feat (profile): added new profile main screen with custom list item

### DIFF
--- a/locales/en/index.yml
+++ b/locales/en/index.yml
@@ -3061,6 +3061,15 @@ features:
       errors:
         data:
           buttonTitle: Go back
+  profile:
+    main:
+      title: "Profile"
+      loading: "Loading..."
+    data:
+      fullName: "Name and Surname"
+      fiscalCode: "Fiscal Code"
+      email: "Email address"
+      birthDate: BirthDate"
 webView:
   error:
     missingParams: Not all information necessary to access this page are available

--- a/locales/it/index.yml
+++ b/locales/it/index.yml
@@ -3088,6 +3088,15 @@ features:
       errors:
         data:
           buttonTitle: Torna indietro
+  profile:
+    main:
+      title: "Profilo"
+      loading: "Caricamento in corso..."
+    data:
+      fullName: "Nome e Cognome"
+      fiscalCode: "Codice Fiscale"
+      email: "Indirizzo email"
+      birthDate: "Data di nascita"
 webView:
   error:
     missingParams: Non sono presenti le informazioni necessarie per accedere a questa pagina

--- a/ts/config.ts
+++ b/ts/config.ts
@@ -164,4 +164,4 @@ export const testOverlayCaption: string | undefined =
 
 // New profile screen design Feature Flag
 export const newProfileScreenEnabled =
-  Config.NEW_PROFILE_SCREEEN_ENABLED === "YES";
+  Config.NEW_PROFILE_SCREEN_ENABLED === "YES";

--- a/ts/features/profile/components/ProfileUserItem.tsx
+++ b/ts/features/profile/components/ProfileUserItem.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { StyleSheet, View } from "react-native";
+import { H3 } from "../../../components/core/typography/H3";
+import { H4 } from "../../../components/core/typography/H4";
+import ItemSeparatorComponent from "../../../components/ItemSeparatorComponent";
+import customVariables from "../../../theme/variables";
+
+type Props = {
+  title: string;
+  subtitle: string;
+  icon: React.ReactElement;
+};
+
+const styles = StyleSheet.create({
+  itemRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    padding: 10
+  },
+  rightPadding: {
+    paddingRight: customVariables.contentPadding
+  }
+});
+
+/**
+ * This component is used to render a single item in the profile screen.
+ * It is composed by a left icon, a title and a subtitle.
+ * @param props
+ * @returns
+ */
+const ProfileUserItem = (props: Props) => (
+  <View>
+    <View style={styles.itemRow}>
+      <View style={styles.rightPadding} testID={"ProfileUserItemIconTestID"}>
+        {props.icon}
+      </View>
+      <View>
+        <H3 testID={"ProfileUserItemTitleTestID"}>{props.title}</H3>
+        <H4 testID={"ProfileUserItemSubTitleTestID"} weight={"Regular"}>
+          {props.subtitle}
+        </H4>
+      </View>
+    </View>
+    <ItemSeparatorComponent noPadded={true} />
+  </View>
+);
+
+export default ProfileUserItem;

--- a/ts/features/profile/components/__tests__/ProfileUserItem.test.tsx
+++ b/ts/features/profile/components/__tests__/ProfileUserItem.test.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { render } from "@testing-library/react-native";
+import ProfileUserItem from "../ProfileUserItem";
+import NameSurnameIcon from "../../../../img/assistance/nameSurname.svg";
+
+type Props = {
+  title: string;
+  subtitle: string;
+  icon: React.ReactElement;
+};
+
+const props: Props = {
+  title: "title",
+  subtitle: "subtitle",
+  icon: <NameSurnameIcon width={24} height={24} />
+};
+
+describe("Test ProfileUserItem", () => {
+  it("should render correctly", () => {
+    const component = renderComponent({ ...props });
+    expect(component).toBeTruthy();
+  });
+  it("should match the snapshot", () => {
+    const component = renderComponent({ ...props });
+    expect(component).toMatchSnapshot();
+  });
+  it("should show correctly the title", () => {
+    const component = renderComponent({ ...props });
+    expect(component.getByTestId("ProfileUserItemTitleTestID")).toBeDefined();
+    expect(component.getAllByText(props.title)).toBeDefined();
+  });
+  it("should show correctly the subtitle", () => {
+    const component = renderComponent({ ...props });
+    expect(
+      component.getByTestId("ProfileUserItemSubTitleTestID")
+    ).toBeDefined();
+    expect(component.getAllByText(props.subtitle)).toBeDefined();
+  });
+  it("should show correctly the icon", () => {
+    const component = renderComponent({ ...props });
+    expect(component.getByTestId("ProfileUserItemIconTestID")).toBeTruthy();
+  });
+});
+
+const renderComponent = ({ title, subtitle, icon }: Props) =>
+  render(<ProfileUserItem title={title} subtitle={subtitle} icon={icon} />);

--- a/ts/features/profile/components/__tests__/__snapshots__/ProfileUserItem.test.tsx.snap
+++ b/ts/features/profile/components/__tests__/__snapshots__/ProfileUserItem.test.tsx.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Test ProfileUserItem should match the snapshot 1`] = `
+<View>
+  <View
+    style={
+      Object {
+        "alignItems": "center",
+        "flexDirection": "row",
+        "padding": 10,
+      }
+    }
+  >
+    <View
+      style={
+        Object {
+          "paddingRight": 24,
+        }
+      }
+      testID="ProfileUserItemIconTestID"
+    >
+      <SvgMock
+        height={24}
+        width={24}
+      />
+    </View>
+    <View>
+      <Text
+        color="bluegreyDark"
+        font="TitilliumWeb"
+        fontStyle={
+          Object {
+            "fontSize": 18,
+          }
+        }
+        style={
+          Array [
+            Object {
+              "fontSize": 18,
+            },
+            Object {
+              "color": "#17324D",
+              "fontFamily": "Titillium Web",
+              "fontStyle": "normal",
+              "fontWeight": "600",
+            },
+          ]
+        }
+        testID="ProfileUserItemTitleTestID"
+        weight="SemiBold"
+        weightColorFactory={[Function]}
+      >
+        title
+      </Text>
+      <Text
+        color="bluegreyDark"
+        font="TitilliumWeb"
+        fontStyle={
+          Object {
+            "fontSize": 16,
+          }
+        }
+        style={
+          Array [
+            Object {
+              "fontSize": 16,
+            },
+            Object {
+              "color": "#17324D",
+              "fontFamily": "Titillium Web",
+              "fontStyle": "normal",
+              "fontWeight": "400",
+            },
+          ]
+        }
+        testID="ProfileUserItemSubTitleTestID"
+        weight="Regular"
+        weightColorFactory={[Function]}
+      >
+        subtitle
+      </Text>
+    </View>
+  </View>
+  <View
+    style={
+      Array [
+        Object {},
+        Object {
+          "backgroundColor": "#C9C9C9",
+        },
+        false,
+        Object {
+          "height": 0.5,
+        },
+      ]
+    }
+  />
+</View>
+`;

--- a/ts/features/profile/screens/ProfileMainScreen.tsx
+++ b/ts/features/profile/screens/ProfileMainScreen.tsx
@@ -1,8 +1,9 @@
 import * as React from "react";
-import { List } from "native-base";
+import { View } from "native-base";
 import { useNavigation } from "@react-navigation/native";
 import { SafeAreaView, ScrollView } from "react-native";
 import * as pot from "italia-ts-commons/lib/pot";
+import { fromNullable } from "fp-ts/lib/Option";
 import I18n from "../../../i18n";
 import {
   profileFiscalCodeSelector,
@@ -12,9 +13,7 @@ import {
   profileBirthDateSelector
 } from "../store/reducers/profile";
 import { LoadingErrorComponent } from "../../bonus/bonusVacanze/components/loadingErrorScreen/LoadingErrorComponent";
-import BaseScreenComponent, {
-  ContextualHelpPropsMarkdown
-} from "../../../components/screens/BaseScreenComponent";
+import BaseScreenComponent from "../../../components/screens/BaseScreenComponent";
 import { getProfile } from "../store/actions";
 import { useOnFirstRender } from "../../../utils/hooks/useOnFirstRender";
 import ProfileUserItem from "../components/ProfileUserItem";
@@ -25,15 +24,10 @@ import InfoIcon from "../../../../img/assistance/info.svg";
 import { useIODispatch, useIOSelector } from "../../../store/hooks";
 import { IOStyles } from "../../../components/core/variables/IOStyles";
 import { H1 } from "../../../components/core/typography/H1";
-
-const contextualHelpMarkdown: ContextualHelpPropsMarkdown = {
-  title: "profile.preferences.contextualHelpTitle",
-  body: "profile.preferences.contextualHelpContent"
-};
+import { emptyContextualHelp } from "../../../utils/emptyContextualHelp";
 
 /**
  * This is the screen that shows the user profile.
- * @param props
  * @returns
  */
 const ProfileMainScreen = (): React.ReactElement => {
@@ -42,9 +36,7 @@ const ProfileMainScreen = (): React.ReactElement => {
 
   const notAvailable = I18n.t("global.remoteStates.notAvailable");
   const profile = useIOSelector(profileSelector);
-  const fullName = useIOSelector(profileFullNameSelector).getOrElse(
-    notAvailable
-  );
+  const fullName = useIOSelector(profileFullNameSelector);
   const email = useIOSelector(profileEmailSelector)
     .fold(notAvailable, _ => _)
     .valueOf();
@@ -77,7 +69,7 @@ const ProfileMainScreen = (): React.ReactElement => {
   };
 
   type ItemProps = {
-    fullName: string;
+    fullName: string | undefined;
     fiscalCode: string;
     email: string;
     birthDate: string;
@@ -88,7 +80,7 @@ const ProfileMainScreen = (): React.ReactElement => {
       id: "profileFullName",
       icon: <NameSurnameIcon width={iconSize} height={iconSize} />,
       title: I18n.t("features.profile.data.fullName"),
-      subtitle: props.fullName
+      subtitle: fromNullable(props.fullName).getOrElse(notAvailable)
     },
     {
       id: "profileFiscalCode",
@@ -126,18 +118,18 @@ const ProfileMainScreen = (): React.ReactElement => {
 
   return (
     <BaseScreenComponent
-      contextualHelpMarkdown={contextualHelpMarkdown}
+      contextualHelp={emptyContextualHelp}
       faqCategories={["profile"]}
       goBack
     >
       <SafeAreaView style={IOStyles.flex}>
         <ScrollView style={[IOStyles.horizontalContentPadding]}>
           <H1>{I18n.t("features.profile.main.title")}</H1>
-          <List>
+          <View>
             {items.map((item, idx) => (
               <ProfileUserItem key={`profile_user_item_${idx}`} {...item} />
             ))}
-          </List>
+          </View>
         </ScrollView>
       </SafeAreaView>
     </BaseScreenComponent>

--- a/ts/features/profile/screens/ProfileMainScreen.tsx
+++ b/ts/features/profile/screens/ProfileMainScreen.tsx
@@ -1,0 +1,119 @@
+import * as React from "react";
+import { List } from "native-base";
+import { useNavigation } from "@react-navigation/native";
+import { connect } from "react-redux";
+import { Dispatch } from "redux";
+import * as pot from "italia-ts-commons/lib/pot";
+import I18n from "../../../i18n";
+import { GlobalState } from "../../../store/reducers/types";
+import {
+  profileFiscalCodeSelector,
+  profileSelector,
+  profileEmailSelector,
+  profileFullNameSelector,
+  profileBirthDateSelector
+} from "../store/reducers/profile";
+import { LoadingErrorComponent } from "../../bonus/bonusVacanze/components/loadingErrorScreen/LoadingErrorComponent";
+import BaseScreenComponent, {
+  ContextualHelpPropsMarkdown
+} from "../../../components/screens/BaseScreenComponent";
+import ScreenContent from "../../../components/screens/ScreenContent";
+import { getProfile } from "../store/actions";
+import { useOnFirstRender } from "../../../utils/hooks/useOnFirstRender";
+import ProfileUserItem from "../components/ProfileUserItem";
+import NameSurnameIcon from "../../../../img/assistance/nameSurname.svg";
+import FiscalCodeIcon from "../../../../img/assistance/fiscalCode.svg";
+import EmailIcon from "../../../../img/assistance/email.svg";
+import InfoIcon from "../../../../img/assistance/info.svg";
+
+const contextualHelpMarkdown: ContextualHelpPropsMarkdown = {
+  title: "profile.preferences.contextualHelpTitle",
+  body: "profile.preferences.contextualHelpContent"
+};
+
+type Props = ReturnType<typeof mapDispatchToProps> &
+  ReturnType<typeof mapStateToProps>;
+
+/**
+ * This is the screen that shows the user profile.
+ * @param props
+ * @returns
+ */
+const ProfileMainScreen = (props: Props): React.ReactElement => {
+  const navigation = useNavigation();
+
+  useOnFirstRender(() => {
+    props.loadProfile();
+  });
+
+  const iconSize = 24;
+
+  return (
+    <BaseScreenComponent
+      contextualHelpMarkdown={contextualHelpMarkdown}
+      faqCategories={["profile"]}
+      goBack
+    >
+      {pot.isLoading(props.profile) ? (
+        <LoadingErrorComponent
+          isLoading={pot.isLoading(props.profile)}
+          loadingCaption={I18n.t("features.profile.main.loading")}
+          onRetry={props.loadProfile}
+          errorText={I18n.t("global.genericError")}
+          onAbort={navigation.goBack}
+        />
+      ) : (
+        <ScreenContent title={I18n.t("features.profile.main.title")}>
+          <List withContentLateralPadding>
+            {/* Show name and surname */}
+            {props.fullName.isSome() && (
+              <ProfileUserItem
+                title={I18n.t("features.profile.data.fullName")}
+                subtitle={props.fullName.value}
+                icon={<NameSurnameIcon width={iconSize} height={iconSize} />}
+              />
+            )}
+            {/* Show fiscalcode */}
+            {props.fiscalCode.isSome() && (
+              <ProfileUserItem
+                title={I18n.t("features.profile.data.fiscalCode")}
+                subtitle={props.fiscalCode.value}
+                icon={<FiscalCodeIcon width={iconSize} height={iconSize} />}
+              />
+            )}
+            {/* Show email */}
+            {props.email.isSome() && (
+              <ProfileUserItem
+                title={I18n.t("features.profile.data.email")}
+                subtitle={props.email.value}
+                icon={<EmailIcon width={iconSize} height={iconSize} />}
+              />
+            )}
+            {/* Show Birthdate */}
+            {props.birthDate.isSome() && (
+              <ProfileUserItem
+                title={I18n.t("features.profile.data.birthDate")}
+                subtitle={props.birthDate.value.toLocaleDateString()}
+                icon={<InfoIcon width={iconSize} height={iconSize} />}
+              />
+            )}
+          </List>
+        </ScreenContent>
+      )}
+    </BaseScreenComponent>
+  );
+};
+
+const mapDispatchToProps = (dispatch: Dispatch) => ({
+  loadProfile: () => dispatch(getProfile.request())
+});
+
+const mapStateToProps = (state: GlobalState) => ({
+  profile: profileSelector(state),
+  fullName: profileFullNameSelector(state),
+  email: profileEmailSelector(state),
+  fiscalCode: profileFiscalCodeSelector(state),
+  birthDate: profileBirthDateSelector(state)
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(ProfileMainScreen);

--- a/ts/features/profile/screens/ProfileMainScreen.tsx
+++ b/ts/features/profile/screens/ProfileMainScreen.tsx
@@ -47,14 +47,14 @@ const ProfileMainScreen = (): React.ReactElement => {
   );
   const email = useIOSelector(profileEmailSelector)
     .fold(notAvailable, _ => _)
-    .toString();
+    .valueOf();
 
   const fiscalCode = useIOSelector(profileFiscalCodeSelector).getOrElse(
     notAvailable
   );
   const birthDate = useIOSelector(profileBirthDateSelector)
     .fold(notAvailable, _ => _.toLocaleDateString())
-    .toString();
+    .valueOf();
 
   useOnFirstRender(() => {
     dispatch(getProfile.request());

--- a/ts/features/profile/screens/ProfileMainScreen.tsx
+++ b/ts/features/profile/screens/ProfileMainScreen.tsx
@@ -112,32 +112,34 @@ const ProfileMainScreen = (): React.ReactElement => {
 
   const items = getItems(itemsProps).filter(it => it.subtitle !== notAvailable);
 
+  if (profile.kind !== "PotSome") {
+    return (
+      <LoadingErrorComponent
+        isLoading={pot.isLoading(profile)}
+        loadingCaption={I18n.t("features.profile.main.loading")}
+        onRetry={() => dispatch(getProfile.request())}
+        errorText={I18n.t("global.genericError")}
+        onAbort={navigation.goBack}
+      />
+    );
+  }
+
   return (
     <BaseScreenComponent
       contextualHelpMarkdown={contextualHelpMarkdown}
       faqCategories={["profile"]}
       goBack
     >
-      {pot.isLoading(profile) ? (
-        <LoadingErrorComponent
-          isLoading={pot.isLoading(profile)}
-          loadingCaption={I18n.t("features.profile.main.loading")}
-          onRetry={() => dispatch(getProfile.request())}
-          errorText={I18n.t("global.genericError")}
-          onAbort={navigation.goBack}
-        />
-      ) : (
-        <SafeAreaView style={IOStyles.flex}>
-          <ScrollView style={[IOStyles.horizontalContentPadding]}>
-            <H1>{I18n.t("features.profile.main.title")}</H1>
-            <List>
-              {items.map((item, idx) => (
-                <ProfileUserItem key={`profile_user_item_${idx}`} {...item} />
-              ))}
-            </List>
-          </ScrollView>
-        </SafeAreaView>
-      )}
+      <SafeAreaView style={IOStyles.flex}>
+        <ScrollView style={[IOStyles.horizontalContentPadding]}>
+          <H1>{I18n.t("features.profile.main.title")}</H1>
+          <List>
+            {items.map((item, idx) => (
+              <ProfileUserItem key={`profile_user_item_${idx}`} {...item} />
+            ))}
+          </List>
+        </ScrollView>
+      </SafeAreaView>
     </BaseScreenComponent>
   );
 };

--- a/ts/features/profile/store/reducers/__tests__/profile.test.ts
+++ b/ts/features/profile/store/reducers/__tests__/profile.test.ts
@@ -1,10 +1,70 @@
 import * as pot from "italia-ts-commons/lib/pot";
+import { createStore } from "redux";
 import { appReducer } from "../../../../../store/reducers";
 import { applicationChangeState } from "../../../../../store/actions/application";
+import { GlobalState } from "../../../../../store/reducers/types";
+import { getProfile } from "../../actions";
+import mockedProfile from "../../../../../__mocks__/initializedProfile";
+import { InitializedProfile } from "../../../../../../definitions/backend/InitializedProfile";
+import {
+  getGenericError,
+  getNetworkErrorMessage,
+  NetworkError
+} from "../../../../../utils/errors";
+
+const profileMocked: InitializedProfile = {
+  ...mockedProfile,
+  is_email_enabled: false,
+  is_email_validated: undefined
+};
+
+const mockFailure: NetworkError = {
+  ...getGenericError(new Error("A generic error"))
+};
+
+const errorFromFailure = new Error(getNetworkErrorMessage(mockFailure));
 
 describe("Test profile reducer behaviour", () => {
-  it("The initial state should be pot.none", () => {
-    const globalState = appReducer(undefined, applicationChangeState("active"));
+  const globalState: GlobalState = appReducer(
+    undefined,
+    applicationChangeState("active")
+  );
+
+  it("the initial state should be pot.none", () => {
     expect(globalState.features.profile).toEqual(pot.none);
+  });
+
+  it("should be pot.noneLoading after the first loading action dispatched", () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, globalState as any);
+
+    store.dispatch(getProfile.request());
+    const profile = store.getState().features.profile;
+
+    expect(profile).toStrictEqual(pot.noneLoading);
+  });
+
+  it("should be pot.some with the response, after the success action", () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, globalState as any);
+
+    store.dispatch(getProfile.request());
+    store.dispatch(getProfile.success(profileMocked));
+
+    expect(store.getState().features.profile).toStrictEqual(
+      pot.some(profileMocked)
+    );
+  });
+
+  it("should be pot.noneError after the failure action", () => {
+    const globalState = appReducer(undefined, applicationChangeState("active"));
+    const store = createStore(appReducer, globalState as any);
+
+    store.dispatch(getProfile.request());
+    store.dispatch(getProfile.failure(mockFailure));
+
+    expect(store.getState().features.profile).toStrictEqual(
+      pot.noneError(errorFromFailure)
+    );
   });
 });

--- a/ts/features/profile/store/reducers/profile.ts
+++ b/ts/features/profile/store/reducers/profile.ts
@@ -29,7 +29,7 @@ const profileReducer = (
 };
 
 export const profileSelector = (state: GlobalState): ProfileState =>
-  state.profile;
+  state.features.profile;
 
 export const profileFullNameSelector = createSelector(
   profileSelector,

--- a/ts/features/profile/store/reducers/profile.ts
+++ b/ts/features/profile/store/reducers/profile.ts
@@ -33,14 +33,10 @@ export const profileSelector = (state: GlobalState): ProfileState =>
 
 export const profileFullNameSelector = createSelector(
   profileSelector,
-  (profile: ProfileState): Option<string> =>
+  (profile: ProfileState): string | undefined =>
     pot.getOrElse(
-      pot.map(profile, p =>
-        fromNullable(p.name).chain(n =>
-          fromNullable(p.family_name).map(f => `${n} ${f}`)
-        )
-      ),
-      none
+      pot.map(profile, p => `${p.name} ${p.family_name}`),
+      undefined
     )
 );
 

--- a/ts/features/profile/store/reducers/profile.ts
+++ b/ts/features/profile/store/reducers/profile.ts
@@ -1,9 +1,13 @@
 import { getType } from "typesafe-actions";
 import * as pot from "italia-ts-commons/lib/pot";
+import { createSelector } from "reselect";
+import { fromNullable, none, Option } from "fp-ts/lib/Option";
 import { InitializedProfile } from "../../../../../definitions/backend/InitializedProfile";
 import { Action } from "../../../../store/actions/types";
 import { getErrorFromNetworkError } from "../../../../utils/errors";
 import { getProfile } from "../actions";
+import { GlobalState } from "../../../../store/reducers/types";
+import { EmailAddress } from "../../../../../definitions/backend/EmailAddress";
 
 export type ProfileState = pot.Pot<InitializedProfile, Error>;
 
@@ -23,5 +27,48 @@ const profileReducer = (
   }
   return state;
 };
+
+export const profileSelector = (state: GlobalState): ProfileState =>
+  state.profile;
+
+export const profileFullNameSelector = createSelector(
+  profileSelector,
+  (profile: ProfileState): Option<string> =>
+    pot.getOrElse(
+      pot.map(profile, p =>
+        fromNullable(p.name).chain(n =>
+          fromNullable(p.family_name).map(f => `${n} ${f}`)
+        )
+      ),
+      none
+    )
+);
+
+export const profileBirthDateSelector = createSelector(
+  profileSelector,
+  (profile: ProfileState): Option<Date> =>
+    pot.getOrElse(
+      pot.map(profile, p => fromNullable(p.date_of_birth)),
+      none
+    )
+);
+
+export const profileFiscalCodeSelector = createSelector(
+  profileSelector,
+  (profile: ProfileState): Option<string> =>
+    pot.getOrElse(
+      pot.map(profile, p => fromNullable(p.fiscal_code)),
+      none
+    )
+);
+
+export const profileEmailSelector = createSelector(
+  profileSelector,
+  (profile: ProfileState): Option<EmailAddress> =>
+    pot.getOrElse(
+      pot.map(profile, p => fromNullable(p.email)),
+      none
+    )
+);
 
 export default profileReducer;

--- a/ts/navigation/ProfileNavigator.ts
+++ b/ts/navigation/ProfileNavigator.ts
@@ -24,7 +24,11 @@ import ShareDataScreen from "../screens/profile/ShareDataScreen";
 import WebPlayground from "../screens/profile/WebPlayground";
 import { Showroom } from "../screens/showroom/Showroom";
 import { PremiumMessagesOptInOutProfileScreen } from "../screens/profile/premiumMessages/PremiumMessagesOptInOutProfileScreen";
-import { premiumMessagesOptInEnabled } from "../config";
+import {
+  newProfileScreenEnabled,
+  premiumMessagesOptInEnabled
+} from "../config";
+import ProfileMainScreen from "../features/profile/screens/ProfileMainScreen";
 import ROUTES from "./routes";
 
 /**
@@ -56,7 +60,7 @@ const ProfileNavigator = createCompatNavigatorFactory(createStackNavigator)(
       screen: PreferencesScreen
     },
     [ROUTES.PROFILE_DATA]: {
-      screen: ProfileDataScreen
+      screen: newProfileScreenEnabled ? ProfileMainScreen : ProfileDataScreen
     },
     [ROUTES.PROFILE_SECURITY]: {
       screen: SecurityScreen


### PR DESCRIPTION
### :warning: THIS PR DEPENDS ON https://github.com/hevelius/io-app/pull/2

## Short description
Added the new profile Main Screen with custom list item component.

https://user-images.githubusercontent.com/49342144/171878895-4893c73d-2cab-4591-a312-f87dfcf4dd9a.mp4

## List of changes proposed in this pull request
- Added profile selectors to get all required data
- Added Main Screen
- Added custom list item component

## How to test
set NEW_PROFILE_SCREEN_ENABLED feature flag to YES and run `yarn run-ios`